### PR TITLE
Use standard grid layout for newsletter list

### DIFF
--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -9,23 +9,24 @@ export interface Props {
   newsletter: CollectionEntry<'newsletters'>;
 }
 const { newsletter } = Astro.props;
-// const { Content } = await post.render();
-// const featured_image = await findImage(newsletter.data.image);
-// TODO: Why is slug broken again?
 
 const formattedDate = formatShortDate(newsletter.data.date);
 const idOfTitle = slugify(newsletter.data.title);
 ---
 
-<article class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 ${newsletter.data.image ? 'md:grid-cols-2' : ''}`}>
-  <div class="relative h-0 pb-[56.25%] md:pb-[75%] lg:pb-[56.25%] overflow-hidden rounded drop-shadow-lg">
-    <ContentImage
-      src={newsletter.data.image}
-      alt={newsletter.data.title}
-      type="newsletter"
-      class="absolute object-contain h-full mb-6 rounded drop-shadow-lg"
-    />
-  </div>
+<article class="mb-6 transition px-4">
+  {
+    newsletter.data.image && (
+      <div class="relative md:h-72 max-w-6xl mx-auto rounded drop-shadow-lg mb-6">
+        <ContentImage
+          src={newsletter.data.image}
+          alt={newsletter.data.title}
+          type="newsletter"
+          class="object-contain md:h-full mb-6 rounded drop-shadow-lg"
+        />
+      </div>
+    )
+  }
   <div>
     <header>
       <h2
@@ -40,7 +41,7 @@ const idOfTitle = slugify(newsletter.data.title);
           {newsletter.data.title}</a
         >
       </h2>
-      <i>{formattedDate}</i>
+      <i class="my-2 block">{formattedDate}</i>
     </header>
     <div class="post-body body whitespace-pre-line">
       {newsletter.data.summary}

--- a/src/pages/newsletter/[...page].astro
+++ b/src/pages/newsletter/[...page].astro
@@ -26,24 +26,18 @@ const meta = {
 ---
 
 <Layout {meta}>
-  <section class="px-6 sm:px-6 py-6 sm:py-6 lg:py-6 mx-auto max-w-4xl">
+  <section class="px-4 py-16 mx-auto max-w-6xl lg:py-20">
     <Headline subtitle={meta.description}>
       {meta.title}
     </Headline>
-    <div>
-      {
-        page.data.map((newsletter) => (
-          <div class="mb-12 md:mb-20">
-            <Newsletter newsletter={newsletter} />
-          </div>
-        ))
-      }
+    <div class="grid gap-6 row-gap-5 md:grid-cols-2 lg:grid-cols-3 -mb-6">
+      {page.data.map((newsletter) => <Newsletter newsletter={newsletter} />)}
     </div>
     <Pagination
-      firstPage={page.url.prev ? '/books' : null}
+      firstPage={page.url.prev ? '/newsletter' : null}
       previousPage={page.url.prev ? page.url.prev : null}
       nextPage={page.url.next ? page.url.next : null}
-      lastPage={page.url.next ? `/books/${Math.round(page.total / page.size)}` : null}
+      lastPage={page.url.next ? `/newsletter/${Math.round(page.total / page.size)}` : null}
       currentPage={page.currentPage}
       totalPages={Math.round(page.total / page.size)}
     />


### PR DESCRIPTION
## Summary
- Refactor `Newsletter.astro` to a vertical card (image on top, content below) matching `Post.astro` and `Story.astro`, so it works as a grid item instead of a bespoke two-column layout
- Update the newsletter list page (`src/pages/newsletter/[...page].astro`) to use the same section/grid classes as blog and stories (`px-4 py-16 mx-auto max-w-6xl lg:py-20` + `grid gap-6 row-gap-5 md:grid-cols-2 lg:grid-cols-3 -mb-6`)
- Fix pagination first/last page links that incorrectly pointed to `/books` instead of `/newsletter`

## Test plan
- [x] `npm run build` completes successfully and the newsletter list page renders with the new grid classes
- [x] Visually spot-check `/newsletter` in a browser for layout/spacing

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdiD1dake56ceshvfZ3fhU)_